### PR TITLE
Update log4jView.tmLanguage for regular expression on "at"

### DIFF
--- a/Log4jView.tmLanguage
+++ b/Log4jView.tmLanguage
@@ -84,7 +84,7 @@
 			<key>comment</key>
 			<string>stacktrace jboss</string>
 			<key>match</key>
-			<string>^(\s*)(at)(.*)(\(.*\))$</string>
+			<string>^(\s*)(at )(.*)(\(.*\))$</string>
 			<key>name</key>
 			<string>string.quoted.log4jview</string>
 		</dict>


### PR DESCRIPTION
Minor update to the regex intended to highlight lines in stack traces that refer to references of _at_, but was also picking up additional lines that started with _at_ such as _atlas_ for example.